### PR TITLE
Replace javaScript with JavaScript

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -144,7 +144,7 @@ function createRangesForTrace (timeRanges, threads, opts) {
       "end": timeRangeEnd,
       "duration": timeRange.duration,
       "parseHTML": 0,
-      "javaScript": 0,
+      "JavaScript": 0,
       "styles": 0,
       "updateLayerTree": 0,
       "layout": 0,
@@ -155,7 +155,7 @@ function createRangesForTrace (timeRanges, threads, opts) {
         "domContentLoaded": 0,
         "loadTime": 0,
         "firstPaint": 0,
-        "javaScript": {
+        "JavaScript": {
 
         }
       },
@@ -266,7 +266,7 @@ function addDurationToResult (slice, result) {
           slice.title == 'MinorGC' ||
           slice.title == 'GCEvent') {
 
-    result['javaScript'] += duration;
+    result['JavaScript'] += duration;
 
     // If we have JS Stacks find out who the culprits are for the
     // JavaScript that is running.
@@ -275,10 +275,10 @@ function addDurationToResult (slice, result) {
       var url = URL.parse(owner);
       var host = url.host;
 
-      if (!result.extendedInfo.javaScript[host])
-        result.extendedInfo.javaScript[host] = 0;
+      if (!result.extendedInfo.JavaScript[host])
+        result.extendedInfo.JavaScript[host] = 0;
 
-      result.extendedInfo.javaScript[host] += duration;
+      result.extendedInfo.JavaScript[host] += duration;
     }
   }
 

--- a/test/bigrig_tests.js
+++ b/test/bigrig_tests.js
@@ -222,10 +222,10 @@ describe('Big Rig', function () {
 
         var jsonData = bigrig.analyze(data);
         expect(
-          jsonData[0].extendedInfo.javaScript['localhost:11080']
+          jsonData[0].extendedInfo.JavaScript['localhost:11080']
         ).to.be.within(277, 278);
         expect(
-          jsonData[0].extendedInfo.javaScript['www.google-analytics.com']
+          jsonData[0].extendedInfo.JavaScript['www.google-analytics.com']
         ).to.be.within(59, 60);
         done();
 


### PR DESCRIPTION
Alright so feel super free to reject this PR but when you showed big-rig on hangouts I saw the lowercase JavaScript.

![example image](https://cloud.githubusercontent.com/assets/617438/10954268/5c977f4c-8344-11e5-9460-dc00e86970f3.png) 

I realise `javaScript` is an object key so by convention it's camelCase so again feel totally free to reject this. I thought it would be easier to just make a PR rather than create an issue and then a PR if you agree :flushed:.
